### PR TITLE
Support anonymous type names as seen in PS2 DWARF

### DIFF
--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -1043,7 +1043,7 @@ fn structure_type_string(
     include_anonymous_def: bool,
 ) -> Result<TypeString> {
     let prefix = if let Some(name) = t.name.as_ref() {
-        if name.starts_with("@") {
+        if name.starts_with('@') {
             struct_def_string(info, typedefs, t)?
         } else if include_keyword {
             match t.kind {
@@ -1077,7 +1077,7 @@ fn enumeration_type_string(
     include_anonymous_def: bool,
 ) -> Result<TypeString> {
     let prefix = if let Some(name) = t.name.as_ref() {
-        if name.starts_with("@") {
+        if name.starts_with('@') {
             enum_def_string(t)?
         } else if include_keyword {
             format!("enum {}", name)
@@ -1102,7 +1102,7 @@ fn union_type_string(
     include_anonymous_def: bool,
 ) -> Result<TypeString> {
     let prefix = if let Some(name) = t.name.as_ref() {
-        if name.starts_with("@") {
+        if name.starts_with('@') {
             union_def_string(info, typedefs, t)?
         } else if include_keyword {
             format!("union {}", name)
@@ -1417,7 +1417,7 @@ pub fn struct_def_string(
         StructureKind::Class => "class".to_string(),
     };
     if let Some(name) = t.name.as_ref() {
-        if name.starts_with("@") {
+        if name.starts_with('@') {
             write!(out, " /* {} */", name)?;
         } else {
             write!(out, " {}", name)?;
@@ -1479,7 +1479,7 @@ pub fn struct_def_string(
 pub fn enum_def_string(t: &EnumerationType) -> Result<String> {
     let mut out = match t.name.as_ref() {
         Some(name) => {
-            if name.starts_with("@") {
+            if name.starts_with('@') {
                 format!("enum /* {} */ {{\n", name)
             } else {
                 format!("enum {} {{\n", name)
@@ -1497,7 +1497,7 @@ pub fn enum_def_string(t: &EnumerationType) -> Result<String> {
 pub fn union_def_string(info: &DwarfInfo, typedefs: &TypedefMap, t: &UnionType) -> Result<String> {
     let mut out = match t.name.as_ref() {
         Some(name) => {
-            if name.starts_with("@") {
+            if name.starts_with('@') {
                 format!("union /* {} */ {{\n", name)
             } else {
                 format!("union {} {{\n", name)

--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -1043,7 +1043,9 @@ fn structure_type_string(
     include_anonymous_def: bool,
 ) -> Result<TypeString> {
     let prefix = if let Some(name) = t.name.as_ref() {
-        if include_keyword {
+        if name.starts_with("@") {
+            struct_def_string(info, typedefs, t)?
+        } else if include_keyword {
             match t.kind {
                 StructureKind::Struct => format!("struct {}", name),
                 StructureKind::Class => format!("class {}", name),
@@ -1075,7 +1077,9 @@ fn enumeration_type_string(
     include_anonymous_def: bool,
 ) -> Result<TypeString> {
     let prefix = if let Some(name) = t.name.as_ref() {
-        if include_keyword {
+        if name.starts_with("@") {
+            enum_def_string(t)?
+        } else if include_keyword {
             format!("enum {}", name)
         } else {
             name.clone()
@@ -1098,7 +1102,9 @@ fn union_type_string(
     include_anonymous_def: bool,
 ) -> Result<TypeString> {
     let prefix = if let Some(name) = t.name.as_ref() {
-        if include_keyword {
+        if name.starts_with("@") {
+            union_def_string(info, typedefs, t)?
+        } else if include_keyword {
             format!("union {}", name)
         } else {
             name.clone()
@@ -1411,7 +1417,11 @@ pub fn struct_def_string(
         StructureKind::Class => "class".to_string(),
     };
     if let Some(name) = t.name.as_ref() {
-        write!(out, " {}", name)?;
+        if name.starts_with("@") {
+            write!(out, " /* {} */", name)?;
+        } else {
+            write!(out, " {}", name)?;
+        }
     }
     let mut wrote_base = false;
     for base in &t.bases {
@@ -1468,7 +1478,13 @@ pub fn struct_def_string(
 
 pub fn enum_def_string(t: &EnumerationType) -> Result<String> {
     let mut out = match t.name.as_ref() {
-        Some(name) => format!("enum {} {{\n", name),
+        Some(name) => {
+            if name.starts_with("@") {
+                format!("enum /* {} */ {{\n", name)
+            } else {
+                format!("enum {} {{\n", name)
+            }
+        }
         None => "enum {\n".to_string(),
     };
     for member in t.members.iter() {
@@ -1480,7 +1496,13 @@ pub fn enum_def_string(t: &EnumerationType) -> Result<String> {
 
 pub fn union_def_string(info: &DwarfInfo, typedefs: &TypedefMap, t: &UnionType) -> Result<String> {
     let mut out = match t.name.as_ref() {
-        Some(name) => format!("union {} {{\n", name),
+        Some(name) => {
+            if name.starts_with("@") {
+                format!("union /* {} */ {{\n", name)
+            } else {
+                format!("union {} {{\n", name)
+            }
+        }
         None => "union {\n".to_string(),
     };
     let mut var_out = String::new();


### PR DESCRIPTION
The MetroWerks compiler (on PS2) will give anonymous types certain compiler-generated names:
* `@class`
* `@enum`
* `@anon#` where `#` is an incrementing value

`@class` and `@enum` strings can be found inside the GC compiler as well, but I'm not sure if they are used differently there.