### PR TITLE
Infer anonymous unions from type layout

### DIFF
--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -1582,7 +1582,7 @@ pub fn struct_def_string(
                 in_union = false;
             }
             if i == anon.member_index {
-                out.push_str(&indent_all_by(indent, "union {\n"));
+                out.push_str(&indent_all_by(indent, "union { // inferred\n"));
                 indent += 4;
                 in_union = true;
             }
@@ -1594,7 +1594,7 @@ pub fn struct_def_string(
                 in_group = false;
             }
             if i == anon.member_index {
-                out.push_str(&indent_all_by(indent, "struct {\n"));
+                out.push_str(&indent_all_by(indent, "struct { // inferred\n"));
                 indent += 4;
                 in_group = true;
             }

--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -1429,9 +1429,14 @@ fn get_anon_unions(info: &DwarfInfo, members: &[StructureMember]) -> Result<Vec<
                 continue;
             }
         }
-        if members[prev].offset == member.offset && member.offset != offset {
+        if member.offset <= members[prev].offset && member.offset != offset {
             offset = member.offset;
-            unions.push(AnonUnion { offset, member_index: prev, member_count: 0 });
+            for (i, member) in members.iter().enumerate() {
+                if member.offset == offset {
+                    unions.push(AnonUnion { offset, member_index: i, member_count: 0 });
+                    break;
+                }
+            }
         }
     }
     for anon in &mut unions {

--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -1580,12 +1580,21 @@ pub fn struct_def_string(
                 Visibility::Public => out.push_str("public:\n"),
             }
         }
+        for anon in &groups {
+            if i == anon.member_index + anon.member_count {
+                indent -= 4;
+                out.push_str(&indent_all_by(indent, "};\n"));
+                in_group = false;
+            }
+        }
         for anon in &unions {
             if i == anon.member_index + anon.member_count {
                 indent -= 4;
                 out.push_str(&indent_all_by(indent, "};\n"));
                 in_union = false;
             }
+        }
+        for anon in &unions {
             if i == anon.member_index {
                 out.push_str(&indent_all_by(indent, "union { // inferred\n"));
                 indent += 4;
@@ -1593,11 +1602,6 @@ pub fn struct_def_string(
             }
         }
         for anon in &groups {
-            if i == anon.member_index + anon.member_count {
-                indent -= 4;
-                out.push_str(&indent_all_by(indent, "};\n"));
-                in_group = false;
-            }
             if i == anon.member_index {
                 out.push_str(&indent_all_by(indent, "struct { // inferred\n"));
                 indent += 4;

--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -1583,6 +1583,9 @@ pub fn struct_def_string(
             }
         }
         for anon in &unions {
+            if anon.member_count < 2 {
+                continue;
+            }
             if i == anon.member_index + anon.member_count {
                 indent -= 4;
                 out.push_str(&indent_all_by(indent, "};\n"));
@@ -1590,6 +1593,9 @@ pub fn struct_def_string(
             }
         }
         for anon in &unions {
+            if anon.member_count < 2 {
+                continue;
+            }
             if i == anon.member_index {
                 out.push_str(&indent_all_by(indent, "union { // inferred\n"));
                 indent += 4;

--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -1472,9 +1472,7 @@ fn get_anon_unions(info: &DwarfInfo, members: &[StructureMember]) -> Result<Vec<
                     continue;
                 }
             }
-            let size =
-                if let Some(size) = member.byte_size { size } else { member.kind.size(info)? };
-            if member.offset + size > max_offset || member.offset < anon.offset {
+            if member.offset >= max_offset || member.offset < anon.offset {
                 break;
             }
             anon.member_count += 1;


### PR DESCRIPTION
The MetroWerks compiler seems to avoid emitting DWARF information for anonymous `struct`s and `union`s that have not been assigned a member name. For example:
```cpp
struct example_struct {
    union {
        int i;
        float f;
        struct {
            char b1;
            char b2;
            char b3;
            char b4;
        };
    };
};
```
The DWARF information will not contain information about the anonymous `union` inside `example_struct` or the anonymous `struct` inside of the `union`. It will only contain information for the raw fields.

In this PR, I have added a best-effort algorithm for inferring these anonymous types by inspecting the offsets of the data members. The general idea is as follows:

* Determine how many anonymous `union`s exist in the structure and which members they contain.
    * Iterate over all of the members, and note any instances where a member's offset is less than or equal to the offset of the member preceding it. This will provide you with the second member of each `union`. Be careful not to note the same member more than once.
    * After obtaining the second member, iterate again from the start of the member list until you find a member with the same offset. This will be the start of the first member of the `union`.
    * Now determine where the start of the last `union` member is by finding the last member in the `struct` with the same offset as the `union`'s first member.
    * Iterate over all members in the `union` except the last, and compute the largest offset (`member.offset + size`).
    * Continue adding fields to the `union` starting from the beginning of the last member until you encounter a member with an offset that is either larger than the offset computed in the previous step, or smaller than the offset of the `union`'s first member.
* Determine the groupings within each `union`, and create anonymous `struct`s from them.
    * This is considerably simpler. It just iterates over the members in the `union`, creating a "split" each time it encounters a member with the same offset as the `union` itself.