### PR TITLE
Emit an error code when `dol diff` does not match

### DIFF
--- a/src/cmd/dol.rs
+++ b/src/cmd/dol.rs
@@ -1534,7 +1534,7 @@ fn diff(args: DiffArgs) -> Result<()> {
                     linked_sym.address,
                 );
             }
-            return Ok(());
+            bail!("Code does not match.");
         }
     }
 
@@ -1575,7 +1575,7 @@ fn diff(args: DiffArgs) -> Result<()> {
             );
             log::error!("Original: {}", hex::encode_upper(orig_data));
             log::error!("Linked:   {}", hex::encode_upper(linked_data));
-            return Ok(());
+            bail!("Data does not match.")
         }
     }
 

--- a/src/cmd/dol.rs
+++ b/src/cmd/dol.rs
@@ -1534,7 +1534,7 @@ fn diff(args: DiffArgs) -> Result<()> {
                     linked_sym.address,
                 );
             }
-            bail!("Code does not match.");
+            std::process::exit(1);
         }
     }
 
@@ -1575,7 +1575,7 @@ fn diff(args: DiffArgs) -> Result<()> {
             );
             log::error!("Original: {}", hex::encode_upper(orig_data));
             log::error!("Linked:   {}", hex::encode_upper(linked_data));
-            bail!("Data does not match.")
+            std::process::exit(1);
         }
     }
 


### PR DESCRIPTION
I came across this issue when my diff CI succeeded despite the elf not matching. This seems preferable in all cases because if someone doesn't care about the status code, they can simply throw it away with `|| true` or the like.