### PR TITLE
Reconstruct "erased" tags from DWARF debugging info

### DIFF
--- a/src/cmd/dwarf.rs
+++ b/src/cmd/dwarf.rs
@@ -236,7 +236,7 @@ where
                         None => (Excluded(tag.key), Unbounded),
                     };
                     for (_, child) in info.tags.range(range) {
-                        if child.has_erased_parent {
+                        if child.is_erased_root {
                             children.push(child);
                         }
                     }

--- a/src/cmd/dwarf.rs
+++ b/src/cmd/dwarf.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{btree_map, BTreeMap},
     io::{stdout, Cursor, Read, Write},
+    ops::Bound::{Excluded, Unbounded},
     path::PathBuf,
     str::from_utf8,
 };
@@ -50,6 +51,10 @@ pub struct DumpArgs {
     #[argp(switch)]
     /// Disable color output.
     no_color: bool,
+    #[argp(switch)]
+    /// Attempt to reconstruct tags that have been removed by the linker, e.g.
+    /// tags from unused functions or functions that have been inlined away.
+    include_erased: bool,
 }
 
 pub fn run(args: Args) -> Result<()> {
@@ -97,15 +102,15 @@ fn dump(args: DumpArgs) -> Result<()> {
                 let name = name.rsplit_once('/').map(|(_, b)| b).unwrap_or(&name);
                 let file_path = out_path.join(format!("{}.txt", name));
                 let mut file = buf_writer(file_path)?;
-                dump_debug_section(&mut file, &obj_file, debug_section)?;
+                dump_debug_section(&args, &mut file, &obj_file, debug_section)?;
                 file.flush()?;
             } else if args.no_color {
                 println!("\n// File {}:", name);
-                dump_debug_section(&mut stdout(), &obj_file, debug_section)?;
+                dump_debug_section(&args, &mut stdout(), &obj_file, debug_section)?;
             } else {
                 let mut writer = HighlightWriter::new(syntax_set.clone(), syntax.clone(), theme);
                 writeln!(writer, "\n// File {}:", name)?;
-                dump_debug_section(&mut writer, &obj_file, debug_section)?;
+                dump_debug_section(&args, &mut writer, &obj_file, debug_section)?;
             }
         }
     } else {
@@ -115,19 +120,20 @@ fn dump(args: DumpArgs) -> Result<()> {
             .ok_or_else(|| anyhow!("Failed to locate .debug section"))?;
         if let Some(out_path) = &args.out {
             let mut file = buf_writer(out_path)?;
-            dump_debug_section(&mut file, &obj_file, debug_section)?;
+            dump_debug_section(&args, &mut file, &obj_file, debug_section)?;
             file.flush()?;
         } else if args.no_color {
-            dump_debug_section(&mut stdout(), &obj_file, debug_section)?;
+            dump_debug_section(&args, &mut stdout(), &obj_file, debug_section)?;
         } else {
             let mut writer = HighlightWriter::new(syntax_set, syntax, theme);
-            dump_debug_section(&mut writer, &obj_file, debug_section)?;
+            dump_debug_section(&args, &mut writer, &obj_file, debug_section)?;
         }
     }
     Ok(())
 }
 
 fn dump_debug_section<W>(
+    args: &DumpArgs,
     w: &mut W,
     obj_file: &object::File<'_>,
     debug_section: Section,
@@ -156,7 +162,7 @@ where
     }
 
     let mut reader = Cursor::new(&*data);
-    let info = read_debug_section(&mut reader, obj_file.endianness().into())?;
+    let info = read_debug_section(&mut reader, obj_file.endianness().into(), args.include_erased)?;
 
     for (&addr, tag) in &info.tags {
         log::debug!("{}: {:?}", addr, tag);
@@ -222,41 +228,54 @@ where
                     }
                     writeln!(w, "*/")?;
 
-                    let children = tag.children(&info.tags);
+                    let mut children = tag.children(&info.tags);
+
+                    // merge in erased tags
+                    let range = match tag.next_sibling(&info.tags) {
+                        Some(next) => (Excluded(tag.key), Excluded(next.key)),
+                        None => (Excluded(tag.key), Unbounded),
+                    };
+                    for (_, child) in info.tags.range(range) {
+                        if child.has_erased_parent {
+                            children.push(child);
+                        }
+                    }
+                    children.sort_by_key(|x| x.key);
+
                     let mut typedefs = BTreeMap::<u32, Vec<u32>>::new();
                     for child in children {
                         let tag_type = match process_cu_tag(&info, child) {
                             Ok(tag_type) => tag_type,
                             Err(e) => {
                                 log::error!(
-                                    "Failed to process tag {} (unit {}): {}",
+                                    "Failed to process tag {:X} (unit {}): {}",
                                     child.key,
                                     unit.name,
                                     e
                                 );
                                 writeln!(
                                     w,
-                                    "// ERROR: Failed to process tag {} ({:?})",
+                                    "// ERROR: Failed to process tag {:X} ({:?})",
                                     child.key, child.kind
                                 )?;
                                 continue;
                             }
                         };
-                        if should_skip_tag(&tag_type) {
+                        if should_skip_tag(&tag_type, child.is_erased) {
                             continue;
                         }
-                        match tag_type_string(&info, &typedefs, &tag_type) {
+                        match tag_type_string(&info, &typedefs, &tag_type, child.is_erased) {
                             Ok(s) => writeln!(w, "{}", s)?,
                             Err(e) => {
                                 log::error!(
-                                    "Failed to emit tag {} (unit {}): {}",
+                                    "Failed to emit tag {:X} (unit {}): {}",
                                     child.key,
                                     unit.name,
                                     e
                                 );
                                 writeln!(
                                     w,
-                                    "// ERROR: Failed to emit tag {} ({:?})",
+                                    "// ERROR: Failed to emit tag {:X} ({:?})",
                                     child.key, child.kind
                                 )?;
                                 continue;

--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -471,8 +471,7 @@ impl Tag {
     /// Returns the next tag sequentially, if any (skipping erased tags)
     pub fn next_tag<'a>(&self, tags: &'a TagMap, include_erased: bool) -> Option<&'a Tag> {
         tags.range(self.key + 1..)
-            .filter(|(_, tag)| include_erased || !tag.is_erased)
-            .next()
+            .find(|(_, tag)| include_erased || !tag.is_erased)
             .map(|(_, tag)| tag)
     }
 }

--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -478,9 +478,7 @@ impl Tag {
 }
 
 pub fn read_debug_section<R>(reader: &mut R, e: Endian, include_erased: bool) -> Result<DwarfInfo>
-where
-    R: BufRead + Seek + ?Sized,
-{
+where R: BufRead + Seek + ?Sized {
     let len = {
         let old_pos = reader.stream_position()?;
         let len = reader.seek(SeekFrom::End(0))?;
@@ -504,9 +502,7 @@ where
 
 #[allow(unused)]
 pub fn read_aranges_section<R>(reader: &mut R, e: Endian) -> Result<()>
-where
-    R: BufRead + Seek + ?Sized,
-{
+where R: BufRead + Seek + ?Sized {
     let len = {
         let old_pos = reader.stream_position()?;
         let len = reader.seek(SeekFrom::End(0))?;
@@ -534,7 +530,12 @@ where
     Ok(())
 }
 
-fn read_tags<R>(reader: &mut R, e: Endian, include_erased: bool, is_erased: bool) -> Result<Vec<Tag>>
+fn read_tags<R>(
+    reader: &mut R,
+    e: Endian,
+    include_erased: bool,
+    is_erased: bool,
+) -> Result<Vec<Tag>>
 where
     R: BufRead + Seek + ?Sized,
 {
@@ -621,9 +622,7 @@ where
 
 // TODO Shift-JIS?
 fn read_string<R>(reader: &mut R) -> Result<String>
-where
-    R: BufRead + ?Sized,
-{
+where R: BufRead + ?Sized {
     let mut str = String::new();
     let mut buf = [0u8; 1];
     loop {
@@ -637,9 +636,7 @@ where
 }
 
 fn read_attribute<R>(reader: &mut R, e: Endian) -> Result<Attribute>
-where
-    R: BufRead + Seek + ?Sized,
-{
+where R: BufRead + Seek + ?Sized {
     let attr_type = u16::from_reader(reader, e)?;
     let attr = AttributeKind::try_from(attr_type).context("Unknown DWARF attribute type")?;
     let form = FormKind::try_from(attr_type & FORM_MASK).context("Unknown DWARF form type")?;
@@ -1436,11 +1433,7 @@ pub fn subroutine_def_string(
                 continue;
             }
             let variable = process_variable_tag(info, tag)?;
-            writeln!(
-                out,
-                "    // -> {}",
-                variable_string(info, typedefs, &variable, false)?
-            )?;
+            writeln!(out, "    // -> {}", variable_string(info, typedefs, &variable, false)?)?;
         }
     }
 

--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -354,8 +354,8 @@ pub struct Attribute {
 pub struct Tag {
     pub key: u32,
     pub kind: TagKind,
-    pub is_erased: bool,
-    pub has_erased_parent: bool,
+    pub is_erased: bool,      // Tag was deleted but has been reconstructed
+    pub is_erased_root: bool, // Tag is erased and is the root of a tree of erased tags
     pub attributes: Vec<Attribute>,
 }
 
@@ -551,7 +551,7 @@ where
             key: position as u32,
             kind: TagKind::Padding,
             is_erased,
-            has_erased_parent: false,
+            is_erased_root: false,
             attributes: Vec::new(),
         });
         return Ok(tags);
@@ -591,7 +591,7 @@ where
                 key: position as u32,
                 kind,
                 is_erased: true,
-                has_erased_parent: true,
+                is_erased_root: true,
                 attributes,
             });
 
@@ -613,7 +613,7 @@ where
             key: position as u32,
             kind: tag,
             is_erased,
-            has_erased_parent: false,
+            is_erased_root: false,
             attributes,
         });
     }


### PR DESCRIPTION
The DWARF info for the OOT GC emulator has useful info that has been partially overwritten by padding tags. Specifically, the overwritten info seems to be tags from things stripped by the linker, mainly unused functions or functions that have been inlined away. So far this has been incredibly helpful so far for figuring out potential inline functions when decomping.

I learned about this because https://github.com/LuigiBlood/dwarfone attempts to include these tags too. It requires some heuristics to parse because the format is not standard, and the first tag's type and length has been overwritten by the padding tag. It's also little-endian unlike the rest of the tags, and there seems to be some MetroWerks-specific stuff too.

I tried to improve the heuristics a little when porting this to dtk. I have no idea if it works for other games, other compiler versions, or C++, so erased tag parsing is hidden behind an `--include-erased` flag. Currently only erased functions are output, it seems like erased local variables are things like `static double _half$localstatic0$sqrtf__Ff` which are more confusing than useful IMO.

Is "erased" a good name for this? Maybe "stripped" or something is better.

Example:
```
$ dtk dwarf dump --include-erased oot-gc/SIM_original.elf
...
// Erased
static int xlFileLoad(char * szFileName /* r30 */, void * ppBuffer /* r31 */) {
    // Local variables
    int nSize; // r1+0x18
    struct tXL_FILE * pFile; // r1+0x14

    // References
    // -> static int (* gpfOpen)(char *, struct DVDFileInfo *);
    // -> struct _XL_OBJECTTYPE gTypeFile;
}
...
```