### PR TITLE
elf2dol: Support section name denylist

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ Creates a DOL file from the provided ELF file.
 
 ```shell
 $ dtk elf2dol input.elf output.dol
+# or, to ignore certain sections
+$ dtk elf2dol input.elf output.dol --ignore debug_section1 --ignore debug_section2
 ```
 
 ### map


### PR DESCRIPTION
Supports excluding certain sections given their names:
```shell
$ dtk elf2dol input.elf output.dol --ignore debug_section1 --ignore debug_section2
```