### PR TITLE
Follow symlinks when looking for disc images

### DIFF
--- a/src/cmd/dol.rs
+++ b/src/cmd/dol.rs
@@ -2067,7 +2067,8 @@ pub fn find_object_base(config: &ProjectConfig) -> Result<ObjectBase> {
         // Search for disc images in the object base directory
         for result in fs::read_dir(&base)? {
             let entry = result?;
-            if entry.file_type()?.is_file() {
+            // Use fs::metadata to follow symlinks
+            if fs::metadata(entry.path())?.file_type().is_file() {
                 let path = check_path_buf(entry.path())?;
                 let mut file = open_file(&path, false)?;
                 let format = nodtool::nod::Disc::detect(file.as_mut())?;


### PR DESCRIPTION
I'm running out of SSD space so I tried symlinking the images and was confused when it didn't work. (I know I can delete the images later, but in the meantime it's ~9 GiB extra space for all the oot-gc versions.)