### PR TITLE
Add new options to rel make

### DIFF
--- a/src/cmd/rel.rs
+++ b/src/cmd/rel.rs
@@ -104,6 +104,9 @@ pub struct MakeArgs {
     #[argp(option, short = 'n')]
     /// (optional) module names
     names: Vec<String>,
+    #[argp(option, short = 'v')]
+    /// (optional) REL version (default is 3)
+    version: Option<u32>,
     #[argp(switch, short = 'w')]
     /// disable warnings
     no_warn: bool,
@@ -364,7 +367,7 @@ fn make(args: MakeArgs) -> Result<()> {
         let _span = info_span!("file", path = %module_info.path).entered();
         let mut info = RelWriteInfo {
             module_id: module_info.module_id,
-            version: 3,
+            version: args.version.unwrap_or(3),
             name_offset: None,
             name_size: None,
             align: None,


### PR DESCRIPTION
Partially handles issue #93 till now by adding the REL version option. When trying to build Mario Party 4 RELs without config, the section count also didn't match up with what it should be.

Which ones exactly would make sense to be configurable manually?