### PR TITLE
Guess endianness of "erased" DWARF info

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ Dumps DWARF 1.1 information from an ELF file. (Does **not** support DWARF 2+)
 
 ```shell
 $ dtk dwarf dump input.elf
+# or, to include data that was stripped by MWLD
+$ dtk dwarf dump input.elf --include-erased
 ```
 
 ### elf disasm

--- a/src/util/reader.rs
+++ b/src/util/reader.rs
@@ -20,6 +20,15 @@ impl From<object::Endianness> for Endian {
     }
 }
 
+impl Endian {
+    pub fn flip(self) -> Self {
+        match self {
+            Endian::Big => Endian::Little,
+            Endian::Little => Endian::Big,
+        }
+    }
+}
+
 pub const DYNAMIC_SIZE: usize = 0;
 
 pub const fn struct_size<const N: usize>(fields: [usize; N]) -> usize {


### PR DESCRIPTION
In the GC OOT emulator, "erased" DWARF data is little-endian despite the ELF being big-endian. In Dr Mario, the "erased" data is apparently still big-endian (different linker version maybe?). So, now `--include-erased` will try to guess which endianness to use for erased DWARF data.

Fixes #85