### PR TITLE
Continue analyzing functions after unknown jumps

### DIFF
--- a/src/analysis/tracker.rs
+++ b/src/analysis/tracker.rs
@@ -417,8 +417,8 @@ impl Tracker {
                 Ok(ExecCbResult::Continue)
             }
             StepResult::Jump(target) => match target {
+                BranchTarget::Return => Ok(ExecCbResult::EndBlock),
                 BranchTarget::Unknown
-                | BranchTarget::Return
                 | BranchTarget::JumpTable { address: RelocationTarget::External, .. } => {
                     let next_addr = ins_addr + 4;
                     if next_addr < function_end {


### PR DESCRIPTION
Currently dtk fails to analyze most of cinePlayer.cpp ActorInstance::checkEventKeys, because it stores a jump table on the stack and dtk can't track this. Instead of giving up, we now add to `possible_missed_branches` after unknown jumps too.