### PR TITLE
Fix the multidimensional array index order in the dwarf

### DIFF
--- a/src/util/dwarf.rs
+++ b/src/util/dwarf.rs
@@ -1147,7 +1147,7 @@ fn array_type_string(
         );
         match dim.size {
             None => out.suffix.insert_str(0, "[]"),
-            Some(size) => out.suffix = format!("[{}]{}", size, out.suffix),
+            Some(size) => out.suffix = format!("{}[{}]", out.suffix, size),
         };
     }
     Ok(out)


### PR DESCRIPTION
They were swapped before.