### PR TITLE
Add option to disable symbol globalization

### DIFF
--- a/src/cmd/dol.rs
+++ b/src/cmd/dol.rs
@@ -234,6 +234,9 @@ pub struct ProjectConfig {
     /// Marks all emitted symbols as "exported" to prevent the linker from removing them.
     #[serde(default = "bool_true", skip_serializing_if = "is_true")]
     pub export_all: bool,
+    /// Promotes local symbols referenced by other units to global.
+    #[serde(default = "bool_true", skip_serializing_if = "is_true")]
+    pub globalize_symbols: bool,
     /// Optional base path for all object files.
     #[serde(with = "unix_path_serde_option", default, skip_serializing_if = "is_default")]
     pub object_base: Option<Utf8UnixPathBuf>,
@@ -259,6 +262,7 @@ impl Default for ProjectConfig {
             symbols_known: false,
             fill_gaps: true,
             export_all: true,
+            globalize_symbols: true,
             object_base: None,
             extract_objects: true,
         }
@@ -967,7 +971,7 @@ fn split_write_obj(
 
     debug!("Splitting {} objects", module.obj.link_order.len());
     let module_name = module.config.name().to_string();
-    let split_objs = split_obj(&module.obj, Some(module_name.as_str()))?;
+    let split_objs = split_obj(&module.obj, Some(module_name.as_str()), config.globalize_symbols)?;
 
     debug!("Writing object files");
     DirBuilder::new()

--- a/src/cmd/elf.rs
+++ b/src/cmd/elf.rs
@@ -136,7 +136,7 @@ fn disasm(args: DisasmArgs) -> Result<()> {
     match obj.kind {
         ObjKind::Executable => {
             log::info!("Splitting {} objects", obj.link_order.len());
-            let split_objs = split_obj(&obj, None)?;
+            let split_objs = split_obj(&obj, None, false)?;
 
             let asm_dir = args.out.join("asm");
             let include_dir = args.out.join("include");


### PR DESCRIPTION
## Summary
- allow disabling automatic global promotion of symbols during split
- wire config flag into split logic
- rename split parameter to `globalize_symbols` and disable globalization for ELF disassembly by default
- remove temporary `globalize_symbols` unit test

## Testing
- `cargo +nightly fmt`
- `cargo +nightly clippy` *(warnings: mismatched lifetime syntaxes)*
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c504363e0883319a15c64ceff2c523