### PR TITLE
Fix `WindowedFile::read`

### DIFF
--- a/src/vfs/common.rs
+++ b/src/vfs/common.rs
@@ -89,7 +89,9 @@ impl Read for WindowedFile {
             return Ok(0);
         }
         let len = buf.len().min(remaining as usize);
-        self.base.read(&mut buf[..len])
+        let n = self.base.read(&mut buf[..len])?;
+        self.pos += n as u64;
+        Ok(n)
     }
 }
 


### PR DESCRIPTION
Fixes an infinite read loop and subsequent OOM when running `rel info` on a REL in Skyward Sword's `rels.arc` VFS.