### PR TITLE
Print array dimensions in the dwarf based on the compiler

### DIFF
--- a/src/util/dwarf/print.rs
+++ b/src/util/dwarf/print.rs
@@ -130,7 +130,13 @@ fn array_type_string(
         );
         match dim.size {
             None => out.suffix.insert_str(0, "[]"),
-            Some(size) => out.suffix = format!("[{}]{}", size, out.suffix),
+            Some(size) => {
+                if info.producer == Producer::MWCC {
+                    out.suffix = format!("[{}]{}", size, out.suffix);
+                } else {
+                    out.suffix = format!("{}[{}]", out.suffix, size);
+                }
+            }
         };
     }
     Ok(out)


### PR DESCRIPTION
I can only test this with ProDG, but I assume that MWCC is the odd one out