### PR TITLE
elf disasm: run detect_strings so .o rodata renders as .string

### DIFF
--- a/src/cmd/elf.rs
+++ b/src/cmd/elf.rs
@@ -16,6 +16,7 @@ use object::{
 use typed_path::Utf8NativePathBuf;
 
 use crate::{
+    analysis::objects::detect_strings,
     obj::ObjKind,
     util::{
         IntoCow, ToCow,
@@ -131,7 +132,13 @@ fn config(args: ConfigArgs) -> Result<()> {
 
 fn disasm(args: DisasmArgs) -> Result<()> {
     log::info!("Loading {}", args.elf_file);
-    let obj = process_elf(&args.elf_file)?;
+    let mut obj = process_elf(&args.elf_file)?;
+    // Detect string-pool symbols (@stringBase*) and other string data so that a
+    // relocatable .o is disassembled with `.string` literals, matching how the
+    // executable `dol split` path (which always runs detect_strings) renders the
+    // same rodata. Without this, string-pool bytes come out as raw `.4byte`
+    // words on the .o side, which desymmetrizes downstream m2c output.
+    detect_strings(&mut obj)?;
     match obj.kind {
         ObjKind::Executable => {
             log::info!("Splitting {} objects", obj.link_order.len());


### PR DESCRIPTION
## Problem

`dtk elf disasm <obj>` does not run the `detect_strings` analysis pass, while the executable `dtk dol split` path does (`cmd/dol.rs`). As a result, string-pool data in a relocatable `.o` (e.g. mwcc `@stringBase*` / string symbols) is disassembled as raw `.4byte` words instead of `.string` literals, so the two paths render the same rodata asymmetrically.

This showed up when diffing an `.o` disassembly against a `dol split` disassembly of the same code: the only differences were string-pool bytes (`.4byte 0x706F7070` vs `.string "popp..."`).

## Fix

Run `detect_strings` in `cmd/elf.rs::disasm` right after `process_elf`, mirroring the `dol split` path. 8 lines.

```rust
let mut obj = process_elf(&args.elf_file)?;
detect_strings(&mut obj)?;
```

## Effect / compatibility

`elf disasm` now emits `.string` for detected string data (was raw `.4byte` words). This is the same rendering `dol split` already produces, so the two paths agree. The only behavioral change is for consumers that relied on raw `.4byte` output from `elf disasm` for string data — likely none, but worth a note.

Builds clean on current `main` (cherry-picked onto v1.8.3). Found while building Wii (RB3) decomp tooling.